### PR TITLE
[Chore] Add 'How to test' section and functional test checkbox to PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -26,10 +26,10 @@ Chore: Changes to the build process or auxiliary tools and libraries such as doc
 
 
 ## How to test
-<!--- Describe how to functionally test this change: the steps to follow,
-required test data or setup, and the expected result. Write it for someone
-who does not know the code. These instructions are also used for functional
-testing of the ticket. -->
+<!--- For the reviewer, who functionally tests this change as part of the
+review. Describe the steps to follow, required test data or setup, and the
+expected result. Write it for someone who does not know the code. These
+instructions are also used for functional testing of the ticket. -->
 
 
 ## Code review priority
@@ -66,4 +66,7 @@ Then, we use a matrix to determine the priority of the Code Review. **Attach** t
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] I have added tests to cover my changes.
-- [ ] I have functionally tested my changes (see 'How to test').
+
+## Reviewer checklist:
+<!--- To be ticked by the reviewer, not the author. -->
+- [ ] I have functionally tested this change using the 'How to test' instructions.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,13 @@ Chore: Changes to the build process or auxiliary tools and libraries such as doc
 <!--- Describe your changes in detail -->
 
 
+## How to test
+<!--- Describe how to functionally test this change: the steps to follow,
+required test data or setup, and the expected result. Write it for someone
+who does not know the code. These instructions are also used for functional
+testing of the ticket. -->
+
+
 ## Code review priority
 First, determine impact and complexity for the PR. More info can be found [here](https://app.gitbook.com/o/-MUKYLddTYNN3QEkR5JF/s/-MUhmjf5u2K1v39Mh4Ic/internal-processes-and-tools/code-reviews).
 
@@ -59,3 +66,4 @@ Then, we use a matrix to determine the priority of the Code Review. **Attach** t
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] I have added tests to cover my changes.
+- [ ] I have functionally tested my changes (see 'How to test').


### PR DESCRIPTION
## Description
Functional testing moves into the PR review, instead of everything waiting in the Functional Test column. The author describes how to test; the reviewer performs the functional test as part of the review. This adds two things to the org-wide PR template:

- A `## How to test` section (right after `## Description`): the author describes how to functionally test the change (steps, test data or setup, expected result), written for someone who does not know the code. The same instructions are reused for functional testing of the ticket in Linear.
- A `## Reviewer checklist:` with one item, to be ticked by the reviewer: `I have functionally tested this change using the 'How to test' instructions.`

The `create-pull-request` skill for Claude Code will be updated separately to fill in the new section and to post the test instructions as a comment on the Linear ticket.

## How to test
Open a new PR in any Safeguardapp repository and check that the template shows the `## How to test` section and the `## Reviewer checklist:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
